### PR TITLE
Replace 'MoveGroupExecuteService' with 'MoveGroupExecuteTrajectoryAct…

### DIFF
--- a/ur5_e_moveit_config/launch/move_group.launch
+++ b/ur5_e_moveit_config/launch/move_group.launch
@@ -50,7 +50,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction


### PR DESCRIPTION
…ion'

Replace 'MoveGroupExecuteService' with 'MoveGroupExecuteTrajectoryAction' in move_group.launch for UR5 e-series.